### PR TITLE
feat: allow multiple services

### DIFF
--- a/examples/hello/internal/endpoint/z_service_endpoints.go
+++ b/examples/hello/internal/endpoint/z_service_endpoints.go
@@ -7,23 +7,23 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-// Endpoints ...
-type Endpoints struct {
+// ServiceEndpoints ...
+type ServiceEndpoints struct {
 	HelloEndpoint endpoint.Endpoint
 	ByeEndpoint   endpoint.Endpoint
 }
 
-// MakeServerEndpoints returns an Endpoints struct where each endpoint invokes
+// MakeServiceEndpoints returns an Endpoints struct where each endpoint invokes
 // the corresponding method on the provided service.
-func MakeServerEndpoints(s hello.Service) Endpoints {
-	return Endpoints{
-		HelloEndpoint: makeHelloEndpoint(s),
-		ByeEndpoint:   makeByeEndpoint(s),
+func MakeServiceEndpoints(s hello.Service) ServiceEndpoints {
+	return ServiceEndpoints{
+		HelloEndpoint: makeServiceHelloEndpoint(s),
+		ByeEndpoint:   makeServiceByeEndpoint(s),
 	}
 }
 
 // makeHelloEndpoint returns an endpoint via the passed service.
-func makeHelloEndpoint(s hello.Service) endpoint.Endpoint {
+func makeServiceHelloEndpoint(s hello.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(*hello.Request)
 		resp, e := s.Hello(ctx, req)
@@ -32,7 +32,7 @@ func makeHelloEndpoint(s hello.Service) endpoint.Endpoint {
 }
 
 // makeByeEndpoint returns an endpoint via the passed service.
-func makeByeEndpoint(s hello.Service) endpoint.Endpoint {
+func makeServiceByeEndpoint(s hello.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(*hello.ByeRequest)
 		resp, e := s.Bye(ctx, req)

--- a/examples/hello/internal/server/z_service_server.go
+++ b/examples/hello/internal/server/z_service_server.go
@@ -13,16 +13,16 @@ import (
 
 // GetServiceOptions ...
 func GetServiceOptions(s hello.Service) []server.Option {
-	serverEndpoints := endpoint.MakeServerEndpoints(s)
+	serverEndpoints := endpoint.MakeServiceEndpoints(s)
 
 	opts := []server.Option{}
 
-	opts = append(opts, getHTTPOptions(serverEndpoints)...)
+	opts = append(opts, getServiceHTTPOptions(serverEndpoints)...)
 
 	return opts
 }
 
-func getHTTPOptions(serverEndpoints endpoint.Endpoints) []server.Option {
+func getServiceHTTPOptions(serverEndpoints endpoint.ServiceEndpoints) []server.Option {
 	opts := []server.Option{}
 
 	opts = append(opts,
@@ -30,20 +30,20 @@ func getHTTPOptions(serverEndpoints endpoint.Endpoints) []server.Option {
 			Method:         "",
 			Path:           "/hello",
 			Endpoint:       serverEndpoints.HelloEndpoint,
-			RequestDecoder: decodeHelloRequest,
+			RequestDecoder: decodeServiceHelloRequest,
 		}),
 		server.WithHTTPEndpoint(httpserver.Endpoint{
 			Method:         "",
 			Path:           "/bye",
 			Endpoint:       serverEndpoints.ByeEndpoint,
-			RequestDecoder: decodeByeRequest,
+			RequestDecoder: decodeServiceByeRequest,
 		}),
 	)
 
 	return opts
 }
 
-func decodeHelloRequest(_ context.Context, r *http.Request) (request interface{}, err error) {
+func decodeServiceHelloRequest(_ context.Context, r *http.Request) (request interface{}, err error) {
 	var req *hello.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func decodeHelloRequest(_ context.Context, r *http.Request) (request interface{}
 	return req, err
 }
 
-func decodeByeRequest(_ context.Context, r *http.Request) (request interface{}, err error) {
+func decodeServiceByeRequest(_ context.Context, r *http.Request) (request interface{}, err error) {
 	var req *hello.ByeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, err


### PR DESCRIPTION
Allow to have multiple services:
- `gokit gen -interface Service` to generate codes for interface `Service`
- `gokit gen -interface Crud` to generate codes for interface `Crud`